### PR TITLE
User excuse connection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,4 +35,11 @@ class ApplicationController < ActionController::API
     puts "params: #{params[:id]}"
     render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == params[:id].to_i
   end
+
+  def authorize_excuse_action
+    puts "AUTHORIZE EXCUSE ACTION"
+    puts "user id: #{get_current_user.id}"
+    puts "params: #{params[:id]}"
+    render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == params[:user_id].to_i
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::API
   def authorize_excuse_action
     puts "AUTHORIZE EXCUSE ACTION"
     puts "user id: #{get_current_user.id}"
-    puts "params: #{params[:id]}"
-    render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == params[:user_id].to_i
+    puts "params: #{excuse_params[:user_id]}"
+    render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == excuse_params[:user_id].to_i
   end
 end

--- a/app/controllers/excuses_controller.rb
+++ b/app/controllers/excuses_controller.rb
@@ -1,7 +1,7 @@
 class ExcusesController < ApplicationController
   before_action :set_excuse, only: [:show, :update, :destroy]
-  # before_action :authenticate_token, except: [:index]
-  # before_action :authorize_user, except: [:index, :destroy]
+  before_action :authenticate_token, except: [:index]
+  before_action :authorize_excuse_action, except: [:index]
 
 
   # GET /excuses

--- a/app/controllers/excuses_controller.rb
+++ b/app/controllers/excuses_controller.rb
@@ -1,6 +1,8 @@
 class ExcusesController < ApplicationController
   before_action :set_excuse, only: [:show, :update, :destroy]
-  # before_action :authorize_user, except: [:index, :update, :destroy]
+  # before_action :authenticate_token, except: [:index]
+  # before_action :authorize_user, except: [:index, :destroy]
+
 
   # GET /excuses
   def index

--- a/app/controllers/excuses_controller.rb
+++ b/app/controllers/excuses_controller.rb
@@ -1,5 +1,6 @@
 class ExcusesController < ApplicationController
   before_action :set_excuse, only: [:show, :update, :destroy]
+  # before_action :authorize_user, except: [:index, :update, :destroy]
 
   # GET /excuses
   def index
@@ -18,7 +19,8 @@ class ExcusesController < ApplicationController
   def create
     excusehash = {
       content: excuse_params[:content],
-      count: excuse_params[:count]
+      count: excuse_params[:count],
+      user_id: excuse_params[:user_id]
     }
 
     @excuse = Excuse.new(excusehash)
@@ -64,6 +66,6 @@ class ExcusesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def excuse_params
-      params.require(:excuse).permit(:content, :count, :occasion)
+      params.require(:excuse).permit(:content, :count, :occasion, :user_id)
     end
 end


### PR DESCRIPTION
added restrictions: only logged in users can create / edit/ delete their own entries
added this to application ctrl
```
def authorize_excuse_action
    puts "AUTHORIZE EXCUSE ACTION"
    puts "user id: #{get_current_user.id}"
    puts "params: #{excuse_params[:user_id]}"
    render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == excuse_params[:user_id].to_i
  end
```
and this to excuse ctrl
```
before_action :authenticate_token, except: [:index]
before_action :authorize_excuse_action, except: [:index]
```