### PR TITLE
fixed bug in authorize_excuse_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,8 +39,9 @@ class ApplicationController < ActionController::API
   def authorize_excuse_action
     puts "AUTHORIZE EXCUSE ACTION"
     puts "user id: #{get_current_user.id}"
-    puts "params: #{excuse_params[:user_id]}"
-    render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == excuse_params[:user_id].to_i
+    puts "params: #{params[:id]}"
+    excuse = Excuse.find(params[:id])
+    render json: {status: 401, message: 'Unauthorized'} unless get_current_user.id == excuse.user_id
   end
 
   def authorize_delete_action

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:8000', 'https://find-the-perfect-excuse.herokuapp.com'
+    origins 'https://find-the-perfect-excuse.herokuapp.com'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
this is what we have on heroku at the moment

--> you'll have to add localhost back in cors and you'll need to change the var $scope.baseurl in app.js to localhost for it to work locally on your computer